### PR TITLE
fix: use emoticons in changelog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: pretty-format-json
-        args: ["--autofix"]
+        args: ["--autofix", "--no-ensure-ascii"]
         files: "\\.(json)$"
 
   # --- Conventional commits ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.3.0](https://github.com/gemmadanks/python-project-template/compare/v0.2.0...v0.3.0) (2025-10-09)
 
 
-### Features
+### 🚀 Features
 
 * add badge for codecov ([c0c5325](https://github.com/gemmadanks/python-project-template/commit/c0c5325390f2805f0f4a003a390e41e6cd831288))
 * upload codecov ([#5](https://github.com/gemmadanks/python-project-template/issues/5)) ([c0c5325](https://github.com/gemmadanks/python-project-template/commit/c0c5325390f2805f0f4a003a390e41e6cd831288))

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,55 +4,55 @@
     ".": {
       "bump-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
-      "changelog-types": [
+      "changelog-sections": [
         {
           "hidden": false,
-          "section": "\ud83d\ude80 Features",
+          "section": "🚀 Features",
           "type": "feat"
         },
         {
           "hidden": false,
-          "section": "\ud83d\udc1b Bug Fixes",
+          "section": "🐛 Bug Fixes",
           "type": "fix"
         },
         {
           "hidden": false,
-          "section": "\ud83d\udce6 Dependencies",
+          "section": "📦 Dependencies",
           "type": "deps"
         },
         {
           "hidden": false,
-          "section": "\u26a1 Performance",
+          "section": "⚡ Performance",
           "type": "perf"
         },
         {
           "hidden": true,
-          "section": "\ud83e\uddf9 Refactoring",
+          "section": "🧹 Refactoring",
           "type": "refactor"
         },
         {
           "hidden": true,
-          "section": "\ud83d\udcda Documentation",
+          "section": "📚 Documentation",
           "type": "docs"
         },
         {
           "hidden": true,
-          "section": "\ud83e\udde9 CI",
+          "section": "🧩 CI",
           "type": "ci"
         },
         {
           "hidden": true,
-          "section": "\ud83d\udd27 Build",
+          "section": "🔧 Build",
           "type": "build"
         },
         {
           "hidden": true,
-          "section": "\ud83e\uddfa Chores",
+          "section": "🧴 Chores",
           "type": "chore"
         },
         {
           "hidden": true,
-          "section": "\ud83e\uddea Tests",
+          "section": "🧪 Tests",
           "type": "test"
         }
       ],


### PR DESCRIPTION
Fixes key in release-please config and prevents pre-commit hook pretty-format-json converting emoticons into C/C++/Java source code.

### Prerequisites checklist
Please check each of the following before merging:
- [x] I have updated any relevant documentation
- [ ] I have added unit tests for any new code
- [ ] I have linked to any relevant issues
- [x] I will squash my commits and, where needed, edit the commit messages to make them more informative follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] This pull request is ready to merge (leave unchecked to indicate a WIP)

### What is the purpose of this pull request?
Check all that apply:
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Changes to an existing feature
- [ ] Refactor
- [ ] Increasing test coverage
- [ ] Other, please explain:

